### PR TITLE
Filter out bought listings from requests page

### DIFF
--- a/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
+++ b/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
@@ -90,7 +90,6 @@ class OwnerListingDetailFragment : Fragment() {
 
         // Add the query constraints: Equal to the selected listing and has requests
         query.whereEqualTo("objectId", listing?.objectId)
-//        query.whereNotEqualTo("listingRequests", null)
 
         query.findInBackground(object: FindCallback<Listing> {
             override fun done(listings: MutableList<Listing>?, e: ParseException?) {

--- a/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
+++ b/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
@@ -108,7 +108,7 @@ class OwnerListingDetailFragment : Fragment() {
 
                         if (temp != null) {
                             for (req in temp) {
-                                if (req.status == FLAGS.DENIED.code)
+                                if (req.status == FLAGS.DENIED.code || req.status == FLAGS.APPROVED.code)
                                     temp2.add(req)
                             }
                         }

--- a/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
+++ b/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
@@ -90,7 +90,7 @@ class OwnerListingDetailFragment : Fragment() {
 
         // Add the query constraints: Equal to the selected listing and has requests
         query.whereEqualTo("objectId", listing?.objectId)
-        query.whereNotEqualTo("listingRequests", null)
+//        query.whereNotEqualTo("listingRequests", null)
 
         query.findInBackground(object: FindCallback<Listing> {
             override fun done(listings: MutableList<Listing>?, e: ParseException?) {
@@ -101,10 +101,15 @@ class OwnerListingDetailFragment : Fragment() {
                     if (listings != null) {
                         val queriedListing : Listing = listings[0]
 
-                        val temp : MutableList<ListingRequest>? = listing!!.getJSONArray("listingRequests")
-                            ?.let { ListingRequest.fromJsonArray(it, listing!!.objectId) }
-                        val temp2 : MutableList<ListingRequest> = mutableListOf()
+                        var temp : MutableList<ListingRequest>? = mutableListOf()
+                        if (listing?.getJSONArray("listingRequests") == null) {
+                            temp = null
+                        } else {
+                            temp = listing!!.getJSONArray("listingRequests")
+                                ?.let { ListingRequest.fromJsonArray(it, listing!!.objectId) }
+                        }
 
+                        val temp2 : MutableList<ListingRequest> = mutableListOf()
 
                         if (temp != null) {
                             for (req in temp) {

--- a/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
+++ b/app/src/main/java/com/example/starca/fragments/OwnerListingDetailFragment.kt
@@ -108,7 +108,7 @@ class OwnerListingDetailFragment : Fragment() {
 
                         if (temp != null) {
                             for (req in temp) {
-                                if (req.status == FLAGS.DENIED.code || req.status == FLAGS.APPROVED.code)
+                                if (req.status == FLAGS.DENIED.code || req.status == FLAGS.BOUGHT.code)
                                     temp2.add(req)
                             }
                         }

--- a/app/src/main/res/layout/item_request.xml
+++ b/app/src/main/res/layout/item_request.xml
@@ -94,11 +94,11 @@
         android:id="@+id/tvRequestStatus"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="220dp"
         android:layout_marginTop="40dp"
-        android:text="TextView"
+        android:layout_marginEnd="10dp"
+        android:text="Awaiting Payment"
         android:visibility="invisible"
-        app:layout_constraintStart_toEndOf="@+id/ivRequesterProfilePhoto"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Fixed listing request status on listing requests page
Fixed issue where new listings would crash when viewing all listing requests if it'd never had a request

closes #68 